### PR TITLE
Fix Errors

### DIFF
--- a/src/main/java/model/Sticker.kt
+++ b/src/main/java/model/Sticker.kt
@@ -3,8 +3,7 @@ package model
 class Sticker(val url: String) {
     val name:String
     get() {
-        val leftIndent = "sticker/"
-        val rightIndent = "/android"
-        return url.substring(url.indexOf(leftIndent) + leftIndent.length, url.indexOf(rightIndent))
+        val r = Regex("sticker/(\\d+)/")
+        return r.find(url)!!.groupValues[1]
     }
 }

--- a/src/main/java/utils/JsoupUtils.kt
+++ b/src/main/java/utils/JsoupUtils.kt
@@ -63,7 +63,7 @@ object JsoupUtils {
     }
 
     fun getPackTitle(doc: Element): String {
-        val element = doc.select("div.mdBox03Inner01").first().select("h3.mdCMN08Ttl").first()
+        val element = doc.select("div.mdBox03Inner01 p").first()
         return element.text().replace("/?%*:|\"<>".toRegex(),"")
     }
 


### PR DESCRIPTION
1. The dom of stickershop had changed, update cssQuery pattern to match the title.
2. The sticker image url can be either android or iPhone, fix get `Sticker` name issue with regex.